### PR TITLE
feat(geolocation): CHECKPOINT - Fetch geolocation data using client side 

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - develop
 
 jobs:
   test-and-build:

--- a/src/app/containers/Homepage/hooks/useHomepage.ts
+++ b/src/app/containers/Homepage/hooks/useHomepage.ts
@@ -1,3 +1,4 @@
+import useGeolocation from '@/hooks/common/useGeolocation'
 import useForecastSWR from '@/hooks/swr/useForecastSWR'
 import useUnsplashSWR from '@/hooks/swr/useUnsplashSWR'
 
@@ -6,15 +7,17 @@ interface Props {
   lon: number
 }
 
-export const useHomepage = ({ lat, lon }: Props) => {
+export const useHomepage = () => {
+  const { latitude, longitude, locationEnabled } = useGeolocation()
   // Fetch weather forecast data
-  const { forecast, isForecastError } = useForecastSWR({ lat, lon })
+  const { forecast, isForecastError } = useForecastSWR({ lat: latitude, lon: longitude })
 
   // Fetch weather image data based on forecast keyword
   const weatherKeyword = forecast?.current.weather[0].main.toLowerCase()
   const { weatherImageUrl, isWeatherImageError } = useUnsplashSWR({ forecast, keyword: weatherKeyword ?? '' })
 
   return {
+    isLocationEnabled: locationEnabled,
     forecast,
     isForecastError,
     weatherImageUrl,

--- a/src/app/containers/Homepage/index.tsx
+++ b/src/app/containers/Homepage/index.tsx
@@ -10,13 +10,10 @@ import EmptyState from '@/components/common/EmptyState'
 import Image from 'next/image'
 import useHomepage from './hooks/useHomepage'
 
-interface HomepageProps {
-  lat: number
-  lon: number
-}
+export default function Homepage() {
+  const { isLocationEnabled, forecast, isForecastError, weatherImageUrl, isWeatherImageError } = useHomepage()
 
-export default function Homepage({ lat, lon }: HomepageProps) {
-  const { forecast, isForecastError, weatherImageUrl, isWeatherImageError } = useHomepage({ lat, lon })
+  if (isLocationEnabled === false) return <EmptyState description="Please activate your device location and reload the page." />
 
   if (isForecastError) return <EmptyState description="An error occurred while fetching weather forecast data, please try again later." />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,12 @@
 import Homepage from '@/app/containers/Homepage'
 import HomepageSkeleton from '@/components/common/Skeleton/HomepageSkeleton'
-import { ENV_VARS_BASE_URL, ENV_VARS_SECRET_KEY } from '@/constants/env-vars'
-import fetcher from '@/services/fetcher'
-import { Geolocation } from '@/types/Geolocation'
 import { Suspense } from 'react'
 
-async function getGeolocationData() {
-  const url = `${ENV_VARS_BASE_URL.geoapifyBaseUrl}/v1/ipinfo?apiKey=${ENV_VARS_SECRET_KEY.geoapifyAccessKey}`
-  const result = await fetcher<Geolocation>(url)
-  return result
-}
-
 export default async function Home() {
-  const geolocation = await getGeolocationData()
-
   return (
     <main className="flex-1 overflow-auto p-4 text-white">
       <Suspense fallback={<HomepageSkeleton />}>
-        <Homepage lat={geolocation.location.latitude} lon={geolocation.location.longitude} />
+        <Homepage />
       </Suspense>
     </main>
   )

--- a/src/helpers/__test__/DateTimeHelpers.test.ts
+++ b/src/helpers/__test__/DateTimeHelpers.test.ts
@@ -39,10 +39,6 @@ describe('DateTime Helpers function', () => {
     expect(result).toMatch(expectedFormat)
   })
 
-  test('Test isPresentTime() output', () => {
-    expect(DateTimeHelpers.isPresentTime({ unix: mockUnixTimestamp })).toBeFalsy()
-  })
-
   test('isToday() should return true if the date is today', () => {
     // 1. Get today Unix timestamp
     const todayTimestamp = Math.floor(Date.now() / 1000)

--- a/src/hooks/common/useGeolocation.ts
+++ b/src/hooks/common/useGeolocation.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+
+export default function useGeolocation() {
+  const [latitude, setLatitude] = useState<number | null>(null)
+  const [longitude, setLongitude] = useState<number | null>(null)
+  const [locationEnabled, setLocationEnabled] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(handleSuccess, handleError)
+  }, [])
+
+  function handleSuccess(pos: GeolocationPosition) {
+    const { latitude, longitude } = pos.coords
+    setLatitude(latitude)
+    setLongitude(longitude)
+    setLocationEnabled(true)
+  }
+
+  function handleError() {
+    setLocationEnabled(false)
+  }
+
+  return {
+    latitude,
+    longitude,
+    locationEnabled,
+  }
+}


### PR DESCRIPTION
PR Description:

Revert geolocation data fetch into client side using `navigator`.

Reason:
After tried to fetch geolocation data on server side using Geoapify, it worked perfectly on development and prod local environment. I was using IP-based method to determine geolocation server-side.

But turns out the IP address seen by Geoapify might not be the end user's IP but that is a server in my deployment environment (Vercel). So it always led to incorrect latitude and longitude data on user facing app (the location was in USA, since Vercel server function region is Washington, D.C., USA (East) – iad1).
This is a common issue when performing geolocation in server-side rendering (SSR) or server-side APIs in Next.js.

So in the end, I reverted it back into client side using `navigator.geolocation`. It's a little bit inaccurate compared to Geoapify location result, so yeah.