### PR TITLE
hotfix(ui): update base bg color and empty state layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-forecast",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={cn('flex flex-col h-dvh', inter.className)}>
+      <body className={cn('flex flex-col h-dvh bg-slate-400', inter.className)}>
         <Header />
         {children}
         <Footer />

--- a/src/components/common/EmptyState/index.tsx
+++ b/src/components/common/EmptyState/index.tsx
@@ -4,9 +4,9 @@ interface Props {
 
 function EmptyState({ description }: Props) {
   return (
-    <main className="flex flex-1 justify-center p-4 text-center items-center">
+    <div className="flex h-full justify-center p-4 text-center items-center">
       <p className="text-xl font-semibold capitalize">{description}</p>
-    </main>
+    </div>
   )
 }
 


### PR DESCRIPTION
# PR Description

1. Fix layout level bg color so that empty state text color would be visible.
2. Update `<EmptyState>` flex layout.

## Screenshot

![image](https://github.com/reggiegunawan88/weather-forecast-app/assets/44907916/e847cad0-9ea9-4dce-8252-7b1d07d1d2a8)
